### PR TITLE
feat: add support for Apple Silicon

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -97,7 +97,15 @@ const getReleaseSource = exports.getReleaseSource = () => (0, _requestPromise2.d
     }
   };
 
-  return _os2.default.arch() === "arm64" ? sources.arm64 : sources[_os2.default.platform()];
+  // Apple Silicon version was released with 9.6.0
+  if (_os2.default.arch() === "arm64") {
+    const [majorVersion, minorVersion] = releaseVersion.split(".");
+    if (Number(majorVersion) >= 9 && Number(minorVersion) >= 6) {
+      return sources.arm64;
+    }
+  }
+
+  return sources[_os2.default.platform()];
 });
 
 /**

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -100,7 +100,7 @@ const getReleaseSource = exports.getReleaseSource = () => (0, _requestPromise2.d
   // Apple Silicon version was released with 9.6.0
   if (_os2.default.arch() === "arm64") {
     const [majorVersion, minorVersion] = releaseVersion.split(".");
-    if (Number(majorVersion) >= 9 && Number(minorVersion) >= 6) {
+    if (Number(majorVersion) > 9 || Number(majorVersion) === 9 && Number(minorVersion) >= 6) {
       return sources.arm64;
     }
   }

--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -85,6 +85,11 @@ const getReleaseSource = exports.getReleaseSource = () => (0, _requestPromise2.d
       filename: `flyway-commandline-${releaseVersion}-linux-x64.tar.gz`,
       folder: `flyway-${releaseVersion}`
     },
+    arm64: {
+      url: `${repoBaseUrl}/${releaseVersion}/flyway-commandline-${releaseVersion}-macosx-arm64.tar.gz`,
+      filename: `flyway-commandline-${releaseVersion}-macosx-arm64.tar.gz`,
+      folder: `flyway-${releaseVersion}`
+    },
     darwin: {
       url: `${repoBaseUrl}/${releaseVersion}/flyway-commandline-${releaseVersion}-macosx-x64.tar.gz`,
       filename: `flyway-commandline-${releaseVersion}-macosx-x64.tar.gz`,
@@ -92,7 +97,7 @@ const getReleaseSource = exports.getReleaseSource = () => (0, _requestPromise2.d
     }
   };
 
-  return sources[_os2.default.platform()];
+  return _os2.default.arch() === "arm64" ? sources.arm64 : sources[_os2.default.platform()];
 });
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -70,7 +70,7 @@ export const getReleaseSource = () =>
     // Apple Silicon version was released with 9.6.0
     if (os.arch() === "arm64") {
       const [majorVersion, minorVersion] = releaseVersion.split(".");
-      if (Number(majorVersion) >= 9 && Number(minorVersion) >= 6) {
+      if (Number(majorVersion) > 9 || (Number(majorVersion) === 9 && Number(minorVersion) >= 6)) {
         return sources.arm64;
       }
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -67,7 +67,15 @@ export const getReleaseSource = () =>
       }
     };
 
-    return os.arch() === "arm64" ? sources.arm64 : sources[os.platform()];
+    // Apple Silicon version was released with 9.6.0
+    if (os.arch() === "arm64") {
+      const [majorVersion, minorVersion] = releaseVersion.split(".");
+      if (Number(majorVersion) >= 9 && Number(minorVersion) >= 6) {
+        return sources.arm64;
+      }
+    }
+
+    return sources[os.platform()];
   });
 
 /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -55,6 +55,11 @@ export const getReleaseSource = () =>
         filename: `flyway-commandline-${releaseVersion}-linux-x64.tar.gz`,
         folder: `flyway-${releaseVersion}`
       },
+      arm64: {
+        url: `${repoBaseUrl}/${releaseVersion}/flyway-commandline-${releaseVersion}-macosx-arm64.tar.gz`,
+        filename: `flyway-commandline-${releaseVersion}-macosx-arm64.tar.gz`,
+        folder: `flyway-${releaseVersion}`
+      },
       darwin: {
         url: `${repoBaseUrl}/${releaseVersion}/flyway-commandline-${releaseVersion}-macosx-x64.tar.gz`,
         filename: `flyway-commandline-${releaseVersion}-macosx-x64.tar.gz`,
@@ -62,7 +67,7 @@ export const getReleaseSource = () =>
       }
     };
 
-    return sources[os.platform()];
+    return os.arch() === "arm64" ? sources.arm64 : sources[os.platform()];
   });
 
 /**


### PR DESCRIPTION
Copied from https://github.com/sgraham785/flywaydb-cli/pull/19

Going to create a fork b/c that repo appears to be dead.

## Why?
- using flywaydb-cli should work on Apple Silicon without needing to install java separately

## How
- flyway now includes an Apple Silicon CLI [as of 9.6.0](https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html#ReleaseNotesforFlywayEngine-Flyway9.6.0(2022-10-26))

## Verify
- run these commands on M1/M2 from repo root:
```sh
npm run build
node dist/installer.js
cd bin
./flyway -configFiles=... migrate
```
- before this PR, I got this error:
```
./flyway: line 51: ./jre/bin/java: Bad CPU type in executable
```
- after this PR, migrate succeeds