### PR TITLE
Do not delete cached downloads when version changes

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -115,10 +115,8 @@ const downloadFlywaySource = exports.downloadFlywaySource = source => {
   if (_fsExtra2.default.existsSync(source.filename)) {
     console.log("Cached file exists, skipping download", source.filename);
     return Promise.resolve(source.filename);
-  } else {
-    (0, _rimraf2.default)(downloadDir, () => {
-      _fsExtra2.default.mkdirSync(downloadDir);
-    });
+  } else if (!_fsExtra2.default.existsSync(downloadDir)) {
+    _fsExtra2.default.mkdirSync(downloadDir);
   }
 
   console.log("Downloading", source.url);
@@ -189,7 +187,6 @@ const extractToLib = exports.extractToLib = file => {
   } else {
     _rimraf2.default.sync(extractDir);
     _fsExtra2.default.mkdirSync(extractDir);
-    return Promise.resolve(extractDir);
   }
 
   if (_path2.default.extname(file) === ".zip") {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -90,10 +90,8 @@ export const downloadFlywaySource = source => {
   if (fs.existsSync(source.filename)) {
     console.log("Cached file exists, skipping download", source.filename);
     return Promise.resolve(source.filename);
-  } else {
-    rimraf(downloadDir, () => {
-      fs.mkdirSync(downloadDir);
-    });
+  } else if (!fs.existsSync(downloadDir)) {
+    fs.mkdirSync(downloadDir);
   }
 
   console.log("Downloading", source.url);
@@ -169,7 +167,6 @@ export const extractToLib = file => {
   } else {
     rimraf.sync(extractDir);
     fs.mkdirSync(extractDir);
-    return Promise.resolve(extractDir);
   }
 
   if (path.extname(file) === ".zip") {

--- a/test/readDotFlywayFile.test.js
+++ b/test/readDotFlywayFile.test.js
@@ -1,0 +1,6 @@
+import test from "ava";
+import sinon from "sinon";
+import rewire from "rewire";
+let utils = rewire("../src/utils");
+
+test.todo("tests for reading version file");


### PR DESCRIPTION
Copied from https://github.com/sgraham785/flywaydb-cli/pull/17

Going to publish a fork b/c that repo appears dead

## Problem context
This is an enhancement on https://github.com/sgraham785/flywaydb-cli/pull/16

### Steps
- project A uses flyway 7.x and project B uses flyway 8.x
- `npm ci` project A, then `npm ci` project B, then `npm ci` project A again

### Expected
- ideally the 2nd install for project A doesn't re-download the 7.x binary, because it's already been cached

### Actual
- 2nd install re-downloads 7.x because the entire cache download folder is deleted whenever version changes

## How does this address the problem?
- don't delete the entire download folder if there's no cached binary
- semi-related problem I hit testing this locally - if `lib` exists from a previously failed extraction, we don't want to return after `rimraf`ing, we need to run the extraction

## Verification
- `npm run test` passes