### PR TITLE
fix: .flyway is higher up after fork

### DIFF
--- a/dist/utils/index.js
+++ b/dist/utils/index.js
@@ -54,7 +54,7 @@ const env = process.env;
 const repoBaseUrl = "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline";
 
 const readDotFlywayFile = () => {
-  let resolveDotFlywayPath = _fsExtra2.default.existsSync(_path2.default.resolve(__dirname, "../../../../", ".flyway")) ? _path2.default.resolve(__dirname, "../../../../", ".flyway") : "";
+  let resolveDotFlywayPath = _fsExtra2.default.existsSync(_path2.default.resolve(__dirname, "../../../../../", ".flyway")) ? _path2.default.resolve(__dirname, "../../../../../", ".flyway") : "";
   // console.log("readDotFlywayFile dotFlywayPath -> ", resolveDotFlywayPath);
   let encoding = "utf8";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aldenquimby/flywaydb-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aldenquimby/flywaydb-cli",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aldenquimby/flywaydb-cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Install latest flywaydb-cli as a node module",
   "main": "dist/installer.js",
   "bin": {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -16,9 +16,9 @@ const repoBaseUrl =
 
 const readDotFlywayFile = () => {
   let resolveDotFlywayPath = fs.existsSync(
-    path.resolve(__dirname, "../../../../", ".flyway")
+    path.resolve(__dirname, "../../../../../", ".flyway")
   )
-    ? path.resolve(__dirname, "../../../../", ".flyway")
+    ? path.resolve(__dirname, "../../../../../", ".flyway")
     : "";
   // console.log("readDotFlywayFile dotFlywayPath -> ", resolveDotFlywayPath);
   let encoding = "utf8";


### PR DESCRIPTION
- finding `.flyway` was failing now that fork is published in `node_modules/@aldenquimby/flywaydb-cli` (one extra folder deep)
- future TODO is to make this more robust... ideally we automatically find the nearest `.flyway`