### PR TITLE
fix: do not use Apple Silicon from a Docker container

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -68,7 +68,7 @@ export const getReleaseSource = () =>
     };
 
     // Apple Silicon version was released with 9.6.0
-    if (os.arch() === "arm64") {
+    if (os.platform() === "darwin" && os.arch() === "arm64") {
       const [majorVersion, minorVersion] = releaseVersion.split(".");
       if (Number(majorVersion) > 9 || (Number(majorVersion) === 9 && Number(minorVersion) >= 6)) {
         return sources.arm64;


### PR DESCRIPTION
Fixes issue with #1 where Apple Silicon is incorrectly downloaded on a linux Docker container